### PR TITLE
페이징 검색기능과 생성 페이지 지도 수정

### DIFF
--- a/src/main/java/com/test/foodtrip/domain/travel/controller/PlaceController.java
+++ b/src/main/java/com/test/foodtrip/domain/travel/controller/PlaceController.java
@@ -100,4 +100,15 @@ public class PlaceController {
                 .body(image);
     }
 
+    @GetMapping("/api/place/photo-references")
+    public ResponseEntity<List<String>> getPhotoReferences(@RequestParam String placeId) {
+        List<String> references = googlePlaceService.getPhotoReferences(placeId);
+
+        if (references.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+
+        return ResponseEntity.ok(references);
+    }
+
 }

--- a/src/main/java/com/test/foodtrip/domain/travel/dto/TravelRouteListItemDTO.java
+++ b/src/main/java/com/test/foodtrip/domain/travel/dto/TravelRouteListItemDTO.java
@@ -1,8 +1,10 @@
 package com.test.foodtrip.domain.travel.dto;
 
+import com.test.foodtrip.domain.travel.entity.TravelRoute;
 import lombok.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -31,6 +33,31 @@ public class TravelRouteListItemDTO {
         this.profileImage = profileImage;
         this.views = views;
         this.placeCount = placeCount;
+    }
+
+    public static TravelRouteListItemDTO fromEntity(TravelRoute route, boolean isBookmarked) {
+        String userName = route.getUser() != null ? route.getUser().getNickname() : "탈퇴한 사용자";
+        String profileImage = route.getUser() != null ? route.getUser().getProfileImage() : null;
+        int placeCount = route.getPlaces() != null ? route.getPlaces().size() : 0;
+
+        TravelRouteListItemDTO dto = new TravelRouteListItemDTO(
+                route.getRouteId(),
+                route.getTitle(),
+                userName,
+                profileImage,
+                route.getViews(),
+                placeCount
+        );
+
+        dto.setBookmarked(isBookmarked);
+
+        // 태그 목록도 추가 가능 (추가로 setTagNames() 호출)
+        List<String> tagNames = route.getTags().stream()
+                .map(t -> t.getTag().getTagName())
+                .collect(Collectors.toList());
+        dto.setTagNames(tagNames);
+
+        return dto;
     }
 
     // ✨ 이 메서드가 없으면 오류 발생

--- a/src/main/java/com/test/foodtrip/domain/travel/repository/TravelRouteRepository.java
+++ b/src/main/java/com/test/foodtrip/domain/travel/repository/TravelRouteRepository.java
@@ -26,4 +26,14 @@ public interface TravelRouteRepository extends JpaRepository<TravelRoute, Long> 
             "WHERE (:keyword IS NULL OR LOWER(t.title) LIKE LOWER(CONCAT('%', :keyword, '%')))" +
             " ORDER BY t.routeId DESC")
     Page<TravelRouteListItemDTO> findPagedList(@Param("keyword") String keyword, Pageable pageable);
+
+    @Query("""
+    SELECT DISTINCT r FROM TravelRoute r
+    LEFT JOIN r.tags t
+    LEFT JOIN r.user u
+    WHERE LOWER(r.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
+       OR LOWER(t.tag.tagName) LIKE LOWER(CONCAT('%', :keyword, '%'))
+       OR LOWER(u.nickname) LIKE LOWER(CONCAT('%', :keyword, '%'))
+""")
+    Page<TravelRoute> searchByTitleTagOrUser(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/resources/templates/travel/course-create.html
+++ b/src/main/resources/templates/travel/course-create.html
@@ -110,7 +110,6 @@
   </div>
 </div>
 <div id="login-info" th:attr="data-user-id=${loginUserId}"></div>
-<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBNg0wn8JiwA7BeSeZ4AUxfKWPqLsDcPHc&libraries=places&callback=initMap" async defer></script>
 <script>
   // 전역 변수 선언
   let map;
@@ -128,7 +127,7 @@
   const loginUserId = document.getElementById('login-info').dataset.userId;
 
   // 지도 초기화 함수
-  function initMap() {
+  window.initMap = function() {
     // 지도 생성
     map = new google.maps.Map(document.getElementById("googleMap"), {
       center: { lat: 36.5, lng: 127.8 }, // 한국 중심
@@ -395,15 +394,8 @@
   }
 
   // 장소 목록에 추가
-  function addPlaceToList(place, index) {
-    // 사진 URL 배열 생성 (최대 5개)
-    const photoUrls = [];
-    if (place.photos && place.photos.length > 0) {
-      const maxPhotos = Math.min(place.photos.length, 5);
-      for (let i = 0; i < maxPhotos; i++) {
-        photoUrls.push(place.photos[i].getUrl({ maxWidth: 500, maxHeight: 300 }));
-      }
-    }
+  async function addPlaceToList(place, index) {
+
     
     // 이전 장소와의 연결선 추가 (두 번째 장소부터)
     let connectorHtml = '';
@@ -431,11 +423,8 @@
           <button class="remove-place-btn"><i class="fas fa-times"></i></button>
         </div>
         <div class="place-content">
-          <div class="place-photos">
-            ${photoUrls.length > 0 ? 
-              photoUrls.map(url => `<img src="${url}" alt="${place.name}" class="place-photo">`).join('') : 
-              '<div class="no-photos">사진이 없습니다</div>'
-            }
+          <div class="place-photos" id="photo-container-${index - 1}">
+            <div class="loading-photo">사진 불러오는 중...</div>
           </div>
           <div class="place-details">
             <div class="detail-item">
@@ -490,6 +479,9 @@
     });
     
     $('#place-list').append(placeItem);
+
+    // ⭐ 사진 렌더링 (캐시+딜레이 방식)
+    await loadPhotoToElement(place, `#photo-container-${index - 1}`);
     
     // 장소가 2개 이상이면 이전 장소와의 경로 계산
     if (index > 1) {
@@ -921,6 +913,90 @@
       }
     });
   }
+
+  const photoCache = {}; // placeId → photoUrl 캐시
+  const photoDelay = 800; // 200ms 간격
+
+  // 특정 장소의 첫 번째 사진 URL 얻기 (없으면 null)
+  function getPhotoUrls(place, maxPhotos = 5) {
+    const cached = photoCache[place.place_id];
+    if (cached) return cached;
+
+    const urls = [];
+    if (place.photos && place.photos.length > 0) {
+      const count = Math.min(place.photos.length, maxPhotos);
+      for (let i = 0; i < count; i++) {
+        urls.push(place.photos[i].getUrl({ maxWidth: 500, maxHeight: 300 }));
+      }
+    }
+
+    photoCache[place.place_id] = urls;
+    return urls;
+  }
+
+  // 사진을 지정된 DOM에 비동기적으로 추가
+  async function loadPhotoToElement(place, containerSelector) {
+    const container = document.querySelector(containerSelector);
+    if (!container) return;
+
+    // 사진 불러오는 중... 요소 제거
+    const loadingText = container.querySelector('.loading-photo');
+    if (loadingText) loadingText.remove();
+
+    // 딜레이 적용
+    await new Promise(resolve => setTimeout(resolve, photoDelay));
+
+    const photoUrls = getPhotoUrls(place);
+    if (photoUrls.length === 0) {
+      const fallback = document.createElement('img');
+      fallback.src = 'https://via.placeholder.com/150?text=No+Image';
+      fallback.alt = place.name;
+      fallback.className = 'place-photo';
+      container.appendChild(fallback);
+      return;
+    }
+
+    for (let url of photoUrls) {
+      const img = document.createElement('img');
+      img.src = url;
+      img.alt = place.name;
+      img.className = 'place-photo';
+      img.onerror = function handler() {
+        if (img.src.includes('no-image.png') || img.src.includes('placeholder.com')) return;
+        img.src = 'https://via.placeholder.com/150?text=No+Image';
+      };
+
+      img.onclick = () => {
+        $('#modal-image').attr('src', img.src);
+        $('#photo-modal').css('display', 'flex');
+      };
+
+      container.appendChild(img);
+    }
+  }
+
+  async function renderPlaces(places) {
+    const list = document.getElementById("place-list");
+    list.innerHTML = "";
+
+    for (let i = 0; i < places.length; i++) {
+      const place = places[i];
+
+      const li = document.createElement("li");
+      li.className = "place-item";
+      li.innerHTML = `
+      <div class="place-info">
+        <div class="photo-container" id="photo-container-${i}"></div>
+        <div class="place-title">${place.name}</div>
+      </div>
+    `;
+      list.appendChild(li);
+
+      // 사진 로드: 지연을 걸어서 하나씩
+      await loadPhotoToElement(place, `#photo-container-${i}`);
+    }
+  }
 </script>
+<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBNg0wn8JiwA7BeSeZ4AUxfKWPqLsDcPHc&libraries=places&callback=initMap" async defer></script>
 </body>
 </html>


### PR DESCRIPTION
## 📌 작업 개요
- 여행 코스 리스트 페이지에 페이징 + 키워드 검색 기능 개선
- 생성 페이지(course-create) 지도 마커/사진 관련 로직 수정

## 🔧 주요 변경 사항
- 제목, 태그, 작성자 기반 검색 가능하도록 Repository 쿼리 수정 (JPQL)
- 검색 시 최신순 정렬 적용 (createdAt DESC)
- `course-list.html`에서 photoReference 기반 이미지 출력 방식 적용
- course-create.html에서 이미지 로딩 시 프록시 방식 변경
- Google Maps 마커 표시 및 사진 로딩 오류 수정
- TravelRouteListItemDTO에 fromEntity() 및 tagNames, bookmark 필드 처리 추가